### PR TITLE
Update tls13ccstest.c, no use of swtich statement

### DIFF
--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -472,9 +472,6 @@ static int test_tls13ccs(int tst)
             goto err;
         break;
 
-    default:
-        TEST_error("Invalid test value");
-        goto err;
     }
 
     ret = 1;


### PR DESCRIPTION
At start of this function, tst variable has been already checked in switch statement for invalid test value. It has been checked again which is a deadcode.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
